### PR TITLE
added CarSelectTireSteerAngle similar to NFSMWExOpts

### DIFF
--- a/NFSCExtraOptions/dllmain.cpp
+++ b/NFSCExtraOptions/dllmain.cpp
@@ -14,7 +14,7 @@ unsigned char minLaps, maxLaps, minTime, maxTime, minOpponents, maxOpponents, cs
 int hotkeyToggleForceHeat, hotkeyForceHeatLevel, hotkeyToggleCops, hotkeyToggleCopLights, hotkeyToggleHeadlights, hotkeyUnlockAllThings, hotkeyAutoDrive, StartingCash, hotkeyDriftMode, ThreadDelay, GameState, SelectableMarkerCount, hotkeyFreezeCamera;
 bool ShowSubs, EnableMoreCarCategories, ShowLanguageSelectScreen, EnableDebugWorldCamera, ExOptsTeamTakeOver, EnableCameras, copLightsEnabled, RemoveNeonBarriers, UnlockStrangeRace, UnlockSeriesCarsAndUpgrades, EnableHeatLevelOverride, AlwaysRain, SkipMovies, EnableSound, EnableMusic, EnableVoice, GarageZoom, GarageRotate, GarageShowcase, ShowDebugCarCustomize, Win10Fix, AugmentedDriftWithEBrake, AutoDrive, UnlockAllThings, EnableSaveLoadHotPos, ShowHiddenTracks, ShowLightStreaks, PauseScreenBlur, HUDShakeEffect, ForceCollectorsEdition, WheelFix, X10Fix, EnableFog, SkipFirstTimeTutorials, ShowMessage, PursuitActionMode, DriftMode, SkipNISs, DebugWatchCarCamera, IsOnFocus, ShowPursuitCops, ShowNonPursuitCops, ShowAllCarsInFE, SkipCareerIntro, AllowMultipleInstances, UncensoredBustedScreen, TimeBugFix, ImmobileColFix, NFSU2StyleLookBackCamera, MoreCarsForOpponents, ShowDebugEventID, NoRevLimiter, NoCatchUp;
 bool forceHeatLevel = 0, once1 = 0, once2 = 0, DebugCamStatus, ToggleCops = 1;
-float SplashScreenTimeLimit, copLightsAmount, LowBeamAmount, HighBeamAmount, MinHeatLevel, MaxHeatLevel, heatLevel, RainAmount, RoadReflection, FallingRainSize, RainIntensity, RainXing, RainFallSpeed, RainGravity, WorldAnimationSpeed, GameSpeed, CarScale, SBRechargeTime, SBRechargeSpeedLimit, SBMassMultiplier, HUDUpdateRate, RadarRange, SpeedingLimit, ExcessiveSpeedingLimit, RecklessDrivingLimit, DriftRaceCollisionThreshold, DebugCameraTurboSpeed, DebugCameraSuperTurboSpeed, IdleCameraTimeout, RacePositionX, RacePositionY;
+float SplashScreenTimeLimit, copLightsAmount, LowBeamAmount, HighBeamAmount, MinHeatLevel, MaxHeatLevel, heatLevel, RainAmount, RoadReflection, FallingRainSize, RainIntensity, RainXing, RainFallSpeed, RainGravity, WorldAnimationSpeed, GameSpeed, CarScale, SBRechargeTime, SBRechargeSpeedLimit, SBMassMultiplier, HUDUpdateRate, RadarRange, SpeedingLimit, ExcessiveSpeedingLimit, RecklessDrivingLimit, DriftRaceCollisionThreshold, DebugCameraTurboSpeed, DebugCameraSuperTurboSpeed, IdleCameraTimeout, RacePositionX, RacePositionY, CarSelectTireSteerAngle;
 float FloatValue1pt00 = 1.0f, FloatValue10pt00 = 10.0f;
 HWND windowHandle;
 
@@ -293,6 +293,7 @@ void Init()
 	ShowLightStreaks = iniReader.ReadInteger("Menu", "ShowLightStreaks", 1) == 1;
 	PauseScreenBlur = iniReader.ReadInteger("Menu", "PauseScreenBlur", 1) == 1;
 	HUDShakeEffect = iniReader.ReadInteger("Menu", "HUDShakeEffect", 1) == 1;
+	CarSelectTireSteerAngle = iniReader.ReadFloat("Menu", "CarSelectTireSteerAngle", 20.6723f);
 	GarageZoom = iniReader.ReadInteger("Menu", "ShowcaseCamInfiniteZoom", 0) == 1;
 	GarageRotate = iniReader.ReadInteger("Menu", "ShowcaseCamInfiniteRotation", 0) == 1;
 	GarageShowcase = iniReader.ReadInteger("Menu", "ShowcaseCamAlwaysEnable", 0) == 1;
@@ -751,6 +752,9 @@ void Init()
 
 	// Fix Invisible Wheels
 	if (WheelFix) injector::WriteMemory<unsigned char>(0x7BDDBC, 0x01, true);
+
+	// Menu Front Tire Angle
+	injector::WriteMemory<float>(0xA7B668, CarSelectTireSteerAngle, true);
 
 	// Garage Hacks
 	if (GarageZoom)

--- a/NFSCExtraOptionsSettings.ini
+++ b/NFSCExtraOptionsSettings.ini
@@ -42,6 +42,7 @@ SplashScreenTimeLimit = 30          // Duration of Splash Screen in seconds. (De
 ShowLightStreaks = 1                // Shows light streaks on menu screens. (0 = False, 1 = True (Default))
 PauseScreenBlur = 1                 // Enables blur on Pause screen. (0 = False, 1 = True (Default))
 HUDShakeEffect = 1                  // Makes HUD shake when you crash. (0 = False, 1 = True (Default))
+CarSelectTireSteerAngle = 20.6723   // Sets the angle of front tires on menus. (Default = 20.6723)
 ShowcaseCamInfiniteZoom = 0         // Zoom hack for Showcase Camera mode. (0 = False (Default), 1 = True)
 ShowcaseCamInfiniteRotation = 0     // Rotation hack for Showcase Camera mode. (0 = False (Default), 1 = True)
 ShowcaseCamAlwaysEnable = 0         // Use Showcase Camera mode on every menu. (0 = False (Default), 1 = True)


### PR DESCRIPTION
This lets you change the tire angle on the frontend menus. Similar to ExOptsTeam/NFSPSExOpts#11 for NFSCExOpts with updated memory address and default float.